### PR TITLE
hacking instructions & check for mueval viability at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cabal-dev/
 TAGS
 tags
 *.tag
+cabal.sandbox.config
+.cabal-sandbox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
 tryhaskell
 =====
 
-Try Haskell!
+Try Haskell at [tryhaskell.org](http://tryhaskell.org/)!
+
+Hacking
+=====
+
+Build tryhaskell
+```
+$ cabal sandbox init
+$ cabal install --only-dependencies
+$ cabal build
+$ cabal sandbox hc-pkg hide monads-tf
+```
+
+Start tryhaskell, hosted at http://127.0.0.1:4001/
+```
+$ env PATH=./.cabal-sandbox/bin:$PATH \
+  GHC_PACKAGE_PATH=$(cabal sandbox hc-pkg list | grep '^/.*\.cabal-sandbox') \
+  ./dist/build/tryhaskell/tryhaskell
+```
+
+tryhaskell does not currently support any command line arguments
+or configuration files.

--- a/src/TryHaskell.hs
+++ b/src/TryHaskell.hs
@@ -24,10 +24,11 @@ import           Snap.Http.Server hiding (Config)
 import           Snap.Util.FileServe
 import           System.Exit
 import           System.Process.Text.Lazy
+import           System.IO (stderr, hPutStrLn)
 
 -- | Start a web server.
 startServer :: IO ()
-startServer =
+startServer = checkMuEval >>
   httpServe server dispatch
   where server = setDefaults defaultConfig
         setDefaults =
@@ -35,6 +36,14 @@ startServer =
           setVerbose False .
           setErrorLog ConfigNoLog .
           setAccessLog ConfigNoLog
+
+-- | Ensure mueval is available and working
+checkMuEval :: IO ()
+checkMuEval = mueval False "()" >>= either die (return () `const`)
+  where
+    die err = hPutStrLn stderr ("ERROR: mueval " ++ msg err) >> exitFailure
+    msg err | T.null err = "failed to start"
+            | otherwise  = "startup failure:\n" ++ T.unpack err
 
 -- | Dispatch on the routes.
 dispatch :: Snap ()

--- a/static/js/tryhaskell.js
+++ b/static/js/tryhaskell.js
@@ -75,8 +75,8 @@ tryhaskell.ajaxCommand = function(line,report){
         dataType: 'json',
         data: { 'exp': line },
         success: function(result){
-            if(result.error){
-                report([{msg:result.error,className:'jquery-console-error'}]);
+            if(result.error !== undefined){
+                report([{msg:result.error || 'Unspecified error. Have you installed mueval?',className:'jquery-console-error'}]);
             } else if (result.success){
                 if(tryhaskell.successHook != null)
                     tryhaskell.successHook(result.success);


### PR DESCRIPTION
This adds some instructions to the README for getting tryhaskell to run, and it adds a quick check at startup to make sure mueval works.

The slight modification to JS is if mueval fails to start the error is "" and "" coerces to false in JS which put it in a state where it simply stopped responding rather than printing an error.
