### PR TITLE
Clarify that lists are not type-limited.

### DIFF
--- a/static/js/tryhaskell.pages.js
+++ b/static/js/tryhaskell.pages.js
@@ -348,8 +348,8 @@ tryhaskell.pages.list =
         {guide:function(result){
             return "<h3>Lists and Tuples</h3>" +
 
-            "<p>You can only " +
-                " have a list of numbers or a list of characters, whereas in a tuple you can throw anything in! </p>" +
+            "<p>You can have a list of numbers, or a list of characters, but you can't have a list containing a mix of numbers and characters." +
+                " In a tuple, however, you can throw anything in! </p>" +
 
             "<p>We've also seen that you can make a new list with <code>(:)</code> that joins two values together, like: </p>" +
                 "<p><code>1 : [2,3]</code></p>" +


### PR DESCRIPTION
The previous wording, at least to me, could be understood to say that lists can only hold numbers, or characters, but could not hold other types. This commit suggests a wording change to clarify that lists are not limited to certain types, but that the element type is uniform.
