### PR TITLE
Towards reproducible deployment

### DIFF
--- a/src/TryHaskell.hs
+++ b/src/TryHaskell.hs
@@ -387,7 +387,7 @@ bodyFooter =
 -- | Scripts; jquery, console, tryhaskell, ga, the usual.
 scripts :: Html
 scripts =
-  do (script ! src "http://code.jquery.com/jquery-2.0.3.min.js") mempty
+  do (script ! src "//code.jquery.com/jquery-2.0.3.min.js") mempty
      (script ! src "/static/js/jquery.console.js") mempty
      (script ! src "/static/js/tryhaskell.js") mempty
      (script ! src "/static/js/tryhaskell.pages.js") mempty


### PR DESCRIPTION
This includes three changes made over the course of getting _tryhaskell_ ready to deploy with [Halcyon](https://halcyon.sh/).
1. Instead of hardcoding port 4001, read the `PORT` environment variable.
2. Give _mueval_ more time, as mentioned in https://github.com/chrisdone/tryhaskell/issues/21#issuecomment-61946338
3. Instead of always loading jQuery over HTTP, use the appropriate protocol.
