### PR TITLE
Warn user if cookies or local storage is disabled

### DIFF
--- a/src/TryHaskell.hs
+++ b/src/TryHaskell.hs
@@ -338,6 +338,7 @@ bodyContent =
   do container
        (row (span12 (do bodyUsers
                         bodyHeader)))
+     warningArea
      consoleArea
      bodyFooter
      scripts
@@ -355,6 +356,18 @@ bodyHeader =
     ((a ! href "/")
        (table (tr (do td ((p !. "haskell-icon") mempty)
                       (td !. "try-haskell") "Try Haskell"))))
+
+-- | An area for warnings (e.g. cookie warning)
+warningArea :: Html
+warningArea =
+  (div !. "warnings")
+    (container
+      (row (do (span6 ! hidden "" !# "cookie-warning")
+                 ((div !. "alert alert-error")
+                   "Cookies are required. Please enable them")
+               (span6 ! hidden "" !# "storage-warning")
+                 ((div !. "alert alert-error")
+                   "Local storage is required. Please enable it"))))
 
 -- | The white area in the middle.
 consoleArea :: Html

--- a/static/js/tryhaskell.js
+++ b/static/js/tryhaskell.js
@@ -32,6 +32,11 @@ try {
     };
 } catch (e){ tryhaskell.files = {} }
 
+tryhaskell.showWarnings = function() {
+    !navigator.cookieEnabled     && $("#cookie-warning").show();
+    window['localStorage']==null && $("#storage-warning").show();
+}
+
 // A pre-command hook which can prevent the command from being run if
 // it returns true.
 tryhaskell.preCommandHook = function(line,report){
@@ -259,6 +264,7 @@ String.prototype.trim = function() {
 
 // Main entry point.
 $(function(){
+    tryhaskell.showWarnings();
     tryhaskell.makeController();
     tryhaskell.makeGuide();
     tryhaskell.activeUsers();


### PR DESCRIPTION
Issue #25

Warnings are sticked between the header and console. By default they
are hidden. JS code checks local storage and cookies support and
shows the warnings accordingly.
