### PR TITLE
Store cached expression in LRUCache

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -11,7 +11,6 @@ import TryHaskell
 -- | Main entry point.
 main :: IO ()
 main =
-  do ((stats,statsT),(cache,cacheT)) <- setupServer
+  do ((stats,statsT),cache) <- setupServer
      finally (startServer cache stats)
-             (do killThread statsT
-                 killThread cacheT)
+             (killThread statsT)

--- a/tryhaskell.cabal
+++ b/tryhaskell.cabal
@@ -38,6 +38,7 @@ library
                    , text
                    , time
                    , unordered-containers
+                   , lrucache
 
 executable tryhaskell
   hs-source-dirs:    src/main


### PR DESCRIPTION
Previously evaluated expressions were stored in HashMap which was
emptied once in an hour by `expireCache` thread.

I propose a better solution which uses `Data.Cache.LRU.IO` from `lrucache` package.

Pros:
- Cache becomes more effective as its not flushed completely each hour
- No need for expiring thread
- Harder to maliciously make the server run out-of-memory, however I am not sure
  if that was possible before
- Less code

Cons:
- Lookup and insertion time should take insignificantly longer as:
  1. LRUCache uses `Data.Map` underneath, if I understand correctly we
     get O(log(n)), instead of O(n) as it was with HashMap
  2. It has to check if the limit was reached and pop elements
     accordingly
- Memory usage per element is slightly higher as there is a need to keep
  track of when it was used
- additional dependency

LFU cache would suit better, but I couldn't find haskell implementation (I am
thinking about implementing it myself).

What do you think?
