### PR TITLE
Declare and locate run-time data files using Cabal

### DIFF
--- a/src/TryHaskell.hs
+++ b/src/TryHaskell.hs
@@ -76,6 +76,7 @@ startServer :: Cache
             -> IO ()
 startServer cache stats =
   do env <- getEnvironment
+     static <- getDataFileName "static"
      let port =
            maybe 4001 read $
            lookup "PORT" env
@@ -85,7 +86,7 @@ startServer cache stats =
            setErrorLog ConfigNoLog .
            setVerbose False
      httpServe (config defaultConfig)
-               (dispatch cache stats)
+               (dispatch static cache stats)
 
 -- | Ensure mueval is available and working
 checkMuEval :: IO ()
@@ -101,9 +102,9 @@ checkMuEval =
             | otherwise  = "startup failure:\n" ++ T.unpack err
 
 -- | Dispatch on the routes.
-dispatch :: Cache -> MVar Stats -> Snap ()
-dispatch cache stats =
-  route [("/static",serveDirectory "static")
+dispatch :: FilePath -> Cache -> MVar Stats -> Snap ()
+dispatch static cache stats =
+  route [("/static",serveDirectory static)
         ,("/eval",eval cache stats)
         ,("/users",users stats)
         ,("/",home stats)]

--- a/tryhaskell.cabal
+++ b/tryhaskell.cabal
@@ -11,6 +11,15 @@ category:            Education
 build-type:          Simple
 cabal-version:       >=1.8
 data-files:          Imports.hs
+                     static/css/fonts/Haskell.dev.svg
+                     static/css/fonts/Haskell.eot
+                     static/css/fonts/Haskell.svg
+                     static/css/fonts/Haskell.ttf
+                     static/css/fonts/Haskell.woff
+                     static/css/tryhaskell.css
+                     static/js/jquery.console.js
+                     static/js/tryhaskell.js
+                     static/js/tryhaskell.pages.js
 
 library
   exposed-modules:   TryHaskell


### PR DESCRIPTION
This allows the `tryhaskell` binary to disregard the current working directory.
