### PR TITLE
Fix issue with non-US keyboards and Alt+Gr key combinations

### DIFF
--- a/static/js/jquery.console.js
+++ b/static/js/jquery.console.js
@@ -301,19 +301,23 @@
 	return false;
       }
       if (acceptInput) {
-	if (e.shiftKey && keyCode in shiftCodes) {
+	if (e.shiftKey && !e.altKey && !e.ctrlKey && keyCode in shiftCodes) {
+	  // Only the shift key was pressed with one of the shift codes
 	  cancelKeyPress = keyCode;
 	  (shiftCodes[keyCode])();
 	  return false;
-	} else if (e.altKey  && keyCode in altCodes) {
+	} else if (e.altKey && !e.shiftKey && !e.ctrlKey && keyCode in altCodes) {
+	  // Only the alt key was pressed with one of the shift codes
 	  cancelKeyPress = keyCode;
 	  (altCodes[keyCode])();
 	  return false;
-	} else if (e.ctrlKey && keyCode in ctrlCodes) {
+	} else if (e.ctrlKey && !e.shiftKey && !e.altKey && keyCode in ctrlCodes) {
+	  // Only the ctrl key was pressed with one of the shift codes
 	  cancelKeyPress = keyCode;
 	  (ctrlCodes[keyCode])();
 	  return false;
-	} else if (keyCode in keyCodes) {
+	} else if (!e.shiftKey && !e.ctrlKey && !e.altKey && keyCode in keyCodes) {
+	  // No modifier key was pressed with one of the normal codes
 	  cancelKeyPress = keyCode;
 	  (keyCodes[keyCode])();
 	  return false;


### PR DESCRIPTION
Many non-US keyboards including my Hungarian one requires AltGr (right Alt) to be held to enter certain special characters. That AltGr also acts as Ctrl+Alt.

There's a problem where certain special characters are caught by the alt/ctrl commands and do a special action rather than type the desired character. E.g. pressing AltGr+B should result in `{` on the Hungarian keyboard, but is caught by Alt+B to move to the previous word instead.

This change should fix this issue by demanding that the modifier keys pressed are exact (only Alt, only Ctrl or only Shift) rather than being lenient to allow for other modifiers to be pressed at the same time too.

I couldn't find any unit test files for adding tests.